### PR TITLE
NET 6 has MaxBy so specify internal to avoid ambiguity

### DIFF
--- a/ICSharpCode.Decompiler/IL/Transforms/ReduceNestingTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/ReduceNestingTransform.cs
@@ -296,7 +296,7 @@ namespace ICSharpCode.Decompiler.IL
 
 			// find the default section, and ensure it has only one incoming edge
 			var switchInst = (SwitchInstruction)switchContainer.EntryPoint.Instructions.Single();
-			var defaultSection = switchInst.Sections.MaxBy(s => s.Labels.Count());
+			var defaultSection = ICSharpCode.Decompiler.Util.CollectionExtensions.MaxBy( switchInst.Sections, s => s.Labels.Count());
 			if (!defaultSection.Body.MatchBranch(out var defaultBlock) || defaultBlock.IncomingEdgeCount != 1)
 				return false;
 			if (defaultBlock.Parent != switchContainer)

--- a/ICSharpCode.Decompiler/IL/Transforms/SwitchOnStringTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/SwitchOnStringTransform.cs
@@ -1009,7 +1009,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			}
 
 			var stringValues = new List<(string Value, ILInstruction TargetBlockOrLeave)>();
-			SwitchSection defaultSection = switchInst.Sections.MaxBy(s => s.Labels.Count());
+			SwitchSection defaultSection = ICSharpCode.Decompiler.Util.CollectionExtensions.MaxBy(switchInst.Sections,s => s.Labels.Count());
 			if (!(defaultSection.Body.MatchBranch(out Block exitOrDefaultBlock) || defaultSection.Body.MatchLeave(out _)))
 				return false;
 			foreach (var section in switchInst.Sections)


### PR DESCRIPTION
Probably should just gate maxBy polyfill with a `#if ! NET6_0_OR_GREATER`  however those are not used anywhere else so did not update the util class and just force used the util verison.