### PR TITLE
Throw ArgumentNullException when HandlerStart is null

### DIFF
--- a/ICSharpCode.Decompiler/ILAst/ILAstBuilder.cs
+++ b/ICSharpCode.Decompiler/ILAst/ILAstBuilder.cs
@@ -869,6 +869,8 @@ namespace ICSharpCode.Decompiler.ILAst {
 				// Cut all handlers
 				tryCatchBlock.CatchBlocks = new List<ILTryCatchBlock.CatchBlock>();
 				foreach(ExceptionHandler eh in handlers) {
+					if (eh.HandlerStart == null)
+						throw new ArgumentNullException(nameof(eh.HandlerStart));
 					uint handlerEndOffset = eh.HandlerEnd?.Offset ?? codeSize;
 					int startIdx = 0;
 					while (startIdx < body.Count && body[startIdx].Offset < eh.HandlerStart.GetOffset()) startIdx++;

--- a/ICSharpCode.Decompiler/ILAst/ILAstBuilder.cs
+++ b/ICSharpCode.Decompiler/ILAst/ILAstBuilder.cs
@@ -869,7 +869,7 @@ namespace ICSharpCode.Decompiler.ILAst {
 				// Cut all handlers
 				tryCatchBlock.CatchBlocks = new List<ILTryCatchBlock.CatchBlock>();
 				foreach(ExceptionHandler eh in handlers) {
-					if (eh.HandlerStart == null)
+					if (eh.HandlerStart is null)
 						throw new ArgumentNullException(nameof(eh.HandlerStart));
 					uint handlerEndOffset = eh.HandlerEnd?.Offset ?? codeSize;
 					int startIdx = 0;


### PR DESCRIPTION
If you edit a exception handler and set HandlerStart to null then dnspy gives [this](https://i.ibb.co/26q8gps/dnspy.png) error and close itself. This commit fixes it.